### PR TITLE
Uses `thread_local` instead of `__thread` on Solaris.

### DIFF
--- a/db_stress_tool/db_stress_shared_state.cc
+++ b/db_stress_tool/db_stress_shared_state.cc
@@ -15,11 +15,7 @@ namespace ROCKSDB_NAMESPACE {
 const uint32_t SharedState::UNKNOWN_SENTINEL = 0xfffffffe;
 const uint32_t SharedState::DELETION_SENTINEL = 0xffffffff;
 #if defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
-#if defined(OS_SOLARIS)
-__thread bool SharedState::ignore_read_error;
-#else
 thread_local bool SharedState::ignore_read_error;
-#endif // OS_SOLARIS
 #else
 bool SharedState::ignore_read_error;
 #endif // ROCKSDB_SUPPORT_THREAD_LOCAL

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -47,11 +47,7 @@ class SharedState {
   // while reading filter blocks in order to ignore the Get/MultiGet result
   // for those calls
 #if defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
-#if defined(OS_SOLARIS)
-  static __thread bool ignore_read_error;
-#else
   static thread_local bool ignore_read_error;
-#endif // OS_SOLARIS
 #else
   static bool ignore_read_error;
 #endif // ROCKSDB_SUPPORT_THREAD_LOCAL

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -12,27 +12,19 @@ namespace ROCKSDB_NAMESPACE {
 #if defined(NPERF_CONTEXT) || !defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
 PerfContext perf_context;
 #else
-#if defined(OS_SOLARIS)
-__thread PerfContext perf_context_;
-#else
 thread_local PerfContext perf_context;
-#endif
 #endif
 
 PerfContext* get_perf_context() {
 #if defined(NPERF_CONTEXT) || !defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
   return &perf_context;
 #else
-#if defined(OS_SOLARIS)
-  return &perf_context_;
-#else
   return &perf_context;
-#endif
 #endif
 }
 
 PerfContext::~PerfContext() {
-#if !defined(NPERF_CONTEXT) && defined(ROCKSDB_SUPPORT_THREAD_LOCAL) && !defined(OS_SOLARIS)
+#if !defined(NPERF_CONTEXT) && defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
   ClearPerLevelPerfContext();
 #endif
 }

--- a/monitoring/perf_context_imp.h
+++ b/monitoring/perf_context_imp.h
@@ -12,12 +12,7 @@ namespace ROCKSDB_NAMESPACE {
 #if defined(NPERF_CONTEXT) || !defined(ROCKSDB_SUPPORT_THREAD_LOCAL)
 extern PerfContext perf_context;
 #else
-#if defined(OS_SOLARIS)
-extern __thread PerfContext perf_context_;
-#define perf_context (*get_perf_context())
-#else
 extern thread_local PerfContext perf_context;
-#endif
 #endif
 
 #if defined(NPERF_CONTEXT)

--- a/util/xxh3p.h
+++ b/util/xxh3p.h
@@ -61,11 +61,13 @@
 
 /* ===   Compiler specifics   === */
 
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
-#  define XXH_RESTRICT   restrict
+#if defined (__cplusplus)
+#  define XXH_RESTRICT __restrict__
 #else
-/* note : it might be useful to define __restrict or __restrict__ for some C++ compilers */
-#  define XXH_RESTRICT   /* disable */
+#  if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* >= C99 */
+#    define XXH_RESTRICT   restrict
+#  else
+#    define XXH_RESTRICT   /* disable */
 #endif
 
 #if defined(__GNUC__)


### PR DESCRIPTION
C++11's `thread_local` has been supported for a while on Solaris-derived
systems. For simple types like `bool`, this works similarly to
`__thread`, but it's different for types requiring dynamic
initialization. This commit moves to `thread_local` everywhere, bringing
the Solaris-platform version in line with all the others.

This is part of a larger set of changes to support building ClickHouse on
[illumos](https://illumos.org).