### PR TITLE
Fix double unlock

### DIFF
--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -814,7 +814,6 @@ class PosixFileSystem : public FileSystem {
                          " acquiring thread " +
                          ToString(prev_info.acquiring_thread),
                      fname, errno);
-      mutex_locked_files.Unlock();
       return result;
     }
 

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -790,8 +790,6 @@ class PosixFileSystem : public FileSystem {
     lhi.acquire_time = current_time;
     lhi.acquiring_thread = Env::Default()->GetThreadID();
 
-    IOStatus result = IOStatus::OK();
-
     mutex_locked_files.Lock();
     // If it already exists in the locked_files set, then it is already locked,
     // and fail this lock attempt. Otherwise, insert it into locked_files.
@@ -809,14 +807,14 @@ class PosixFileSystem : public FileSystem {
       errno = ENOLCK;
       // Note that the thread ID printed is the same one as the one in
       // posix logger, but posix logger prints it hex format.
-      result = IOError("lock hold by current process, acquire time " +
+      return IOError("lock hold by current process, acquire time " +
                          ToString(prev_info.acquire_time) +
                          " acquiring thread " +
                          ToString(prev_info.acquiring_thread),
                      fname, errno);
-      return result;
     }
 
+    IOStatus result = IOStatus::OK();
     int fd;
     int flags = cloexec_flags(O_RDWR | O_CREAT, nullptr);
 


### PR DESCRIPTION
This was changed in #4 to unlock the mutex after using prev_info, then upstream applied a different fix (getting a copy instead of a reference) and after #9 the code ended up with 2 patches (and 2 unlocks). As the old patch isn't necessary, just get an exact copy of the upstream file avoiding any differences.